### PR TITLE
feat: limit utterances to given number

### DIFF
--- a/rsa_tools.py
+++ b/rsa_tools.py
@@ -2,7 +2,7 @@ import itertools
 import torch
 
 
-def get_utterances(vocab_size, max_length, interactions=None):
+def get_utterances(vocab_size, max_length, interactions=None, limit_utterances=0):
     if interactions:
         utterances = get_unique_utterances(interactions)
     else:
@@ -13,6 +13,12 @@ def get_utterances(vocab_size, max_length, interactions=None):
 
     # Convert to one-hot encoding
     utterances = torch.nn.functional.one_hot(utterances, num_classes=vocab_size).float()
+
+    # Randomly sample utterances up to limit_utterances if given
+    if limit_utterances > 0:
+        num_random_samples = min(limit_utterances, utterances.shape[0])
+        random_indices = torch.randperm(utterances.shape[0])[:num_random_samples]
+        utterances = utterances[random_indices]
 
     return utterances
 

--- a/train.py
+++ b/train.py
@@ -99,6 +99,8 @@ def get_params(params):
     parser.add_argument("--load_interaction", type=bool, default=False,
                         help="If given, load all interactions from previous runs in the folder. Else, take interaction"
                              "from the current run.")
+    parser.add_argument("--limit_utterances", type=int, default=0,
+                        help="Limit loaded or generated utterances to given number. 0 means all.")
     parser.add_argument("--test_rsa", type=str, default=None,
                         help="Use for testing the RSA speaker after training. Can be 'train', 'validation' or 'test'.")
     parser.add_argument("--cost-factor", type=float, default=0.01,
@@ -274,7 +276,7 @@ def train(opts, datasets, verbose_callbacks=False):
                 interaction = torch.load(opts.interaction_path)
 
             # Get utterances from the (loaded or current) interaction
-            utterances = get_utterances(vocab_size, max_len, [interaction])
+            utterances = get_utterances(vocab_size, max_len, [interaction], opts.limit_utterances)
 
             # Set data split
             if opts.test_rsa == 'train':

--- a/train.py
+++ b/train.py
@@ -97,7 +97,8 @@ def get_params(params):
     parser.add_argument("--load_checkpoint", type=bool, default=False,
                         help="Skip training and load pretrained models from checkpoint.")
     parser.add_argument("--load_interaction", type=bool, default=False,
-                        help="If given, load all interactions from previous runs in the folder.")
+                        help="If given, load all interactions from previous runs in the folder. Else, take interaction"
+                             "from the current run.")
     parser.add_argument("--test_rsa", type=str, default=None,
                         help="Use for testing the RSA speaker after training. Can be 'train', 'validation' or 'test'.")
     parser.add_argument("--cost-factor", type=float, default=0.01,
@@ -269,9 +270,11 @@ def train(opts, datasets, verbose_callbacks=False):
                                                    dump_dir=opts.save_interactions_path)
         if opts.test_rsa:
             if opts.load_interaction:
-                # Use interaction for the current run
+                # Load given interaction
                 interaction = torch.load(opts.interaction_path)
-                utterances = get_utterances(vocab_size, max_len, [interaction])
+
+            # Get utterances from the (loaded or current) interaction
+            utterances = get_utterances(vocab_size, max_len, [interaction])
 
             # Set data split
             if opts.test_rsa == 'train':


### PR DESCRIPTION
whether loaded or generated, number of utterances used can now be limited to given number with --limit_utterances

example usage:
python train.py --test_rsa validation --load_interaction True --limit_utterances 100

Fix:
If --test_rsa is given without --load_interaction, we get an error when getting utterances.
To fix this, we can use the interaction from the latest run, which is already there as the "interaction" variable.