### PR TITLE
fix: remove softmax, change loss-acc calculation, new vision module

### DIFF
--- a/create_datasets.py
+++ b/create_datasets.py
@@ -7,27 +7,30 @@ from load import load_data
 from vision_module import feat_rep_vision_module
 
 
-class shapes_dataset(Dataset):
+class ShapesDataset(Dataset):
     """
     This class uses given image, label and feature representation arrays to make a pytorch dataset out of them.
     The feature representations are left empty until 'generate_dataset()' is used to fill them.
     """
-    def __init__(self, images = [], labels = [], feat_reps = [], transform = None):
-
+    def __init__(self, images=None, labels=None, feat_reps=None, transform=None):
+        if images is None and labels is None:
+            raise ValueError('No images or labels given')
         self.images = images  # array shape originally [480000,64,64,3], uint8 in range(256)
         self.feat_reps = feat_reps
         self.labels = labels  # array shape originally [480000,6], float64
-        self.transform = transform # if transform should be applied
+        self.transform = transform
     
     def __len__(self):
         return len(self.labels)
     
-    def __getitem__(self, index):
-        img = self.images[index]
-        label = self.labels[index]
+    def __getitem__(self, idx):
+        if torch.is_tensor(idx):
+            idx = idx.tolist()
+        img = self.images[idx]
+        label = self.labels[idx]
         if self.transform:
             img = self.transform(img)
-        return (img, label)
+        return img, label
 
 def generate_dataset():
     """
@@ -36,22 +39,27 @@ def generate_dataset():
     print("Starting to create the feature representation dataset")
     # load the trained model from save
     model = feat_rep_vision_module()
+    model_path = './models/vision_module'
+    dataset_path = 'dataset/complete_dataset'
     try:
-        model.load_state_dict(torch.load('./models/vision_module'), strict=False)
+        model.load_state_dict(torch.load(model_path), strict=False)
     except:
-        raise ValueError('No trained vision module found in /models/vision_module')
+        raise ValueError(f'No trained vision module found in {model_path}. Please train the model first.')
 
     if torch.cuda.is_available():
-        model.cuda()
-    
+        device = torch.device('cuda')
+    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+        device = torch.device('mps')
+    else:
+        device = torch.device('cpu')
+
+    model.to(device)
     model.eval()
-
-    data = torch.load('./dataset/complete_dataset')
-
+    data = torch.load(dataset_path)
     data_loader = torch.utils.data.DataLoader(data,
-                                            batch_size = 32, 
-                                            shuffle = False,
-                                            pin_memory = True)
+                                              batch_size=32,
+                                              shuffle=False,
+                                              pin_memory=True)
     
     images = []
     labels = []
@@ -59,9 +67,8 @@ def generate_dataset():
 
     with torch.no_grad():
         for i, (input, target) in enumerate(data_loader):
-            if torch.cuda.is_available():
-                input = input.cuda()
-                target = target.cuda()
+            input = input.to(device)
+            target = target.to(device=device, dtype=torch.float32)
             
             feat_rep = model(input)
 
@@ -78,41 +85,28 @@ def generate_dataset():
 
     # for size reasons the dataset is saved twice, 
     # once as the full dataset now including the feature representations
-    feat_rep_dataset_full = shapes_dataset(np.array(images), np.array(labels), np.array(feature_representations))
-    torch.save(feat_rep_dataset_full, './dataset/complete_dataset')
+    feat_rep_dataset_full = ShapesDataset(np.array(images), np.array(labels), np.array(feature_representations))
+    torch.save(feat_rep_dataset_full, dataset_path + '_feat_rep')
 
     # and once as a much smaller dataset with the labels and feature representations but without the original images
-    feat_rep_dataset_without_images = shapes_dataset(labels=np.array(labels), feat_reps=np.array(feature_representations))
-    torch.save(feat_rep_dataset_without_images, './dataset/feat_rep_dataset')
+    feat_rep_dataset_without_images = ShapesDataset(labels=np.array(labels), feat_reps=np.array(feature_representations))
+    torch.save(feat_rep_dataset_without_images, dataset_path + '_feat_rep_no_images')
 
-    print("Saved feature representation dataset to /dataset twice, once with (complete_dataset) and once without images (feat_rep_datset)")
+    print(f"Feature representations saved to {dataset_path + '_feat_rep'} and {dataset_path + '_feat_rep_no_images'}")
     return feat_rep_dataset_full, feat_rep_dataset_without_images
 
 if __name__ == "__main__":
+    feat_rep_dataset_path = 'dataset/complete_dataset_20241027_norm' + '_feat_rep'
     try:
-        
-        complete_data = torch.load('./dataset/complete_dataset')
-    
+        complete_dataset = torch.load(feat_rep_dataset_path)
     except:
-        input_shape = [3,64,64]
-        
-        full_data, labels_reg, full_labels = load_data(input_shape, normalize=False,
-                                                                        subtract_mean=False,
-                                                                        trait_weights=None,
-                                                                        return_trait_weights=False,
-                                                                        return_full_labels=True,
-                                                                        datapath=None)
-        
-        complete_data = shapes_dataset(full_data, labels_reg)
-
-        torch.save(complete_data, './dataset/complete_dataset')
-    # generate the dataset with the feature representations first
-    complete_dataset,_ = generate_dataset()
+        print('Feature representations not found, creating it instead...')
+        complete_dataset, _ = generate_dataset()
 
     # generate concept datasets for the communication game
-    feat_rep_concept_dataset = DataSet(game_size=4, is_shapes3d=True, images=complete_dataset.feat_reps, labels=complete_dataset.labels)
+    feat_rep_concept_dataset = DataSet(game_size=4, is_shapes3d=True, images=complete_dataset.feat_reps, labels=complete_dataset.labels, device='mps')
     torch.save(feat_rep_concept_dataset, './dataset/feat_rep_concept_dataset_new')
 
     # also for the zero_shot dataset
-    feat_rep_zero_concept_dataset = DataSet(game_size=4, zero_shot=True, is_shapes3d=True, images=complete_dataset.feat_reps, labels=complete_dataset.labels)
+    feat_rep_zero_concept_dataset = DataSet(game_size=4, zero_shot=True, is_shapes3d=True, images=complete_dataset.feat_reps, labels=complete_dataset.labels, device='mps')
     torch.save(feat_rep_zero_concept_dataset, './dataset/feat_rep_zero_concept_dataset_new')

--- a/vision_module.py
+++ b/vision_module.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 import torch.nn.functional as F
+import torch
 
 class vision_module(nn.Module):
     """
@@ -16,10 +17,9 @@ class vision_module(nn.Module):
         self.dense2 = nn.Linear(in_features = 180, out_features = 100)
 
         self.classification = nn.Linear(in_features = 100, out_features = num_classes)
-        self.softmax = nn.Softmax(dim=0)
-    
+
     def forward(self, x):
-        x = x.float()
+        x = x.to(device='mps', dtype=torch.float32)
         out = self.pool(F.relu(self.conv1(x)))
         out = F.relu(self.conv2(out))
 
@@ -30,10 +30,15 @@ class vision_module(nn.Module):
         out = F.relu(self.dense2(out))
 
         out = self.classification(out)
-        out = self.softmax(out)
 
         return out
 
+    def predict(self, x):
+        if len(x.shape) == 3:
+            x = x.unsqueeze(0)
+        out = self.forward(x)
+        out = self.softmax(out)
+        return out
 
 class feat_rep_vision_module(nn.Module):
     """
@@ -50,7 +55,7 @@ class feat_rep_vision_module(nn.Module):
         self.dense2 = nn.Linear(in_features = 180, out_features = 100)
     
     def forward(self, x):
-        x = x.float()
+        x = x.to(device='mps', dtype=torch.float32)
         out = self.pool(F.relu(self.conv1(x)))
         out = F.relu(self.conv2(out))
 


### PR DESCRIPTION
- Contrary to Tensorflow's default, Torch's cross-entropy loss function does the softmax itself and therefore expects logits. Remove the softmax layer from vision module's output so we can calculate the loss correctly.
- Add a predict() function to be able to test the CNN properly.
- Change loss and accuracy calculation to speed up training. Instead of calculating accuracy one datapoint at a time, calculate based on current batch.
- Add vision module trained for 15 epoch, which has over 99.5% accuracy. This vision module has been tested manually and produces the correct labels.
- Remove unused code for relational labels - we only use the full labels at this point.
- Add support for mps (Apple silicon) - can be removed later
- Rename shapes_dataset class to ShapesDataset based on Python naming conventions (classes should follow CapWords convention) https://peps.python.org/pep-0008/#class-names